### PR TITLE
consumer timeout set to 0

### DIFF
--- a/poc-impl/src/test/scala/com/gaston/hello/lagom/PocHelloMessagePublisherTest.scala
+++ b/poc-impl/src/test/scala/com/gaston/hello/lagom/PocHelloMessagePublisherTest.scala
@@ -51,7 +51,8 @@ class PocHelloMessagePublisherTest
             "db.default.password" -> postgresql.password,
             "db.default.driver" -> postgresql.driverClassName,
             "akka.kafka.consumer.kafka-clients.enable.auto.commit" -> true,
-            "kafka.brokers" -> kafka.bootstrapServers
+            "kafka.brokers" -> kafka.bootstrapServers,
+            "akka.kafka.consumer.stop-timeout" -> 0
           ).underlying
         override lazy val readSide = new ReadSideTestDriver()
       }


### PR DESCRIPTION
consumer timeout can be set to 0 because the stream is being manually stopped by the control consumer
more details here -> https://doc.akka.io/docs/alpakka-kafka/current/consumer.html#draining-control